### PR TITLE
Should still be able to get simplecov reports

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,10 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+unless ENV['TRAVIS'].nil?
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'


### PR DESCRIPTION
when running rspec locally, without Travis-CI (so disable the formatter unless TRAVIS is set in env)